### PR TITLE
Replace python3 loader with python, closes #16.

### DIFF
--- a/trailsave.plugin
+++ b/trailsave.plugin
@@ -1,5 +1,5 @@
 [Plugin]
-Loader=python3
+Loader=python
 Module=trailsave
 IAge=3
 Name=Trailsave


### PR DESCRIPTION
Fixes this error when enabling the plugin under Ubuntu 12.04:

```
(gedit:2132): libpeas-WARNING **: Could not find loader 'python3' for plugin 'trailsave'
```

See http://askubuntu.com/a/302431
