### PR TITLE
Now preserves trail spaces when the file is a Markdown one

### DIFF
--- a/trailsave.py
+++ b/trailsave.py
@@ -46,6 +46,9 @@ class SaveWithoutTrailingSpacePlugin(GObject.Object, Gedit.ViewActivatable):
     def on_document_saving(self, *args):
         """Strip trailing spaces in document."""
 
+        if self.doc.get_short_name_for_display().endswith(".md"):
+            return
+
         self.doc.begin_user_action()
         self.strip_trailing_spaces()
         self.strip_eof_newlines()


### PR DESCRIPTION
This simple fix preserves the trail spaces when editing a markdown file. In these cases it is paramount to preserve them because they are used to specify that a carriage return isn't a new-paragraph indicator, but just a new-line-in-the-same-paragraph
